### PR TITLE
Fix white scrollbar on the dark scheme

### DIFF
--- a/Solarized Dark.icls
+++ b/Solarized Dark.icls
@@ -1,4 +1,4 @@
-<scheme name="Solarized Dark" version="142" parent_scheme="Default">
+<scheme name="Solarized Dark" version="142" parent_scheme="Darcula">
   <colors>
     <option name="ADDED_LINES_COLOR" value="10483e" />
     <option name="ANNOTATIONS_COLOR" value="7899a4" />


### PR DESCRIPTION
This fixes the white scrollbar, which shows up at least on macOS in the run pane, when using the dark scheme.

Before:
![Screenshot 2019-05-25 at 14 36 36](https://user-images.githubusercontent.com/33625218/58368803-8502fc80-7efa-11e9-9d21-2544b03ab501.png)

After:
![Screenshot 2019-05-25 at 14 31 19](https://user-images.githubusercontent.com/33625218/58368774-48cf9c00-7efa-11e9-999c-f9b5ae177ae8.png)

The idea for the fix was taken from here: https://github.com/ChrisRM/material-theme-jetbrains/issues/1160#issuecomment-486075242