### PR TITLE
Define BUILD.BUILTIN_NAME

### DIFF
--- a/resources/editor/SolarizedDark.xml
+++ b/resources/editor/SolarizedDark.xml
@@ -239,6 +239,7 @@
         <option name="ERROR_STRIPE_COLOR" value="4f443f" />
       </value>
     </option>
+    <option name="BUILD.BUILTIN_NAME" baseAttributes="DEFAULT_PREDEFINED_SYMBOL" />
     <option name="CLASS_REFERENCE">
       <value>
         <option name="FOREGROUND" value="b38700" />

--- a/resources/editor/SolarizedDarkHardGray.xml
+++ b/resources/editor/SolarizedDarkHardGray.xml
@@ -239,6 +239,7 @@
         <option name="ERROR_STRIPE_COLOR" value="4f443f" />
       </value>
     </option>
+    <option name="BUILD.BUILTIN_NAME" baseAttributes="DEFAULT_PREDEFINED_SYMBOL" />
     <option name="CLASS_REFERENCE">
       <value>
         <option name="FOREGROUND" value="b38700" />

--- a/resources/editor/SolarizedLight.xml
+++ b/resources/editor/SolarizedLight.xml
@@ -243,6 +243,7 @@
         <option name="ERROR_STRIPE_COLOR" value="fdc1b2" />
       </value>
     </option>
+    <option name="BUILD.BUILTIN_NAME" baseAttributes="DEFAULT_PREDEFINED_SYMBOL" />
     <option name="CLASS_REFERENCE">
       <value>
         <option name="FOREGROUND" value="b38700" />

--- a/resources/editor/SolarizedLightHardGray.xml
+++ b/resources/editor/SolarizedLightHardGray.xml
@@ -243,6 +243,7 @@
         <option name="ERROR_STRIPE_COLOR" value="fdc1b2" />
       </value>
     </option>
+    <option name="BUILD.BUILTIN_NAME" baseAttributes="DEFAULT_PREDEFINED_SYMBOL" />
     <option name="CLASS_REFERENCE">
       <value>
         <option name="FOREGROUND" value="b38700" />


### PR DESCRIPTION
This defaults to `#000080` otherwise, which is really hard to read in SolarizedDark.
| Before | After |
| ------ | ----- |
| <img width="418" alt="before" src="https://user-images.githubusercontent.com/296840/115637901-9d812900-a354-11eb-8c48-872403b5c6e6.png"> | <img width="422" alt="after" src="https://user-images.githubusercontent.com/296840/115637908-a114b000-a354-11eb-8326-f26f5b6114ff.png"> |
