### PR TITLE
Set nicer default for dark inline hints

### DIFF
--- a/resources/editor/SolarizedDark.xml
+++ b/resources/editor/SolarizedDark.xml
@@ -1017,6 +1017,12 @@
         <option name="BACKGROUND" value="393d" />
       </value>
     </option>
+    <option name="INLAY_DEFAULT">
+      <value>
+        <option name="FOREGROUND" value="7a7a7a" />
+        <option name="BACKGROUND" value="0e3c4a" />
+      </value>
+    </option>
     <option name="INLINE_PARAMETER_HINT">
       <value>
         <option name="FOREGROUND" value="657b83" />


### PR DESCRIPTION
As mentioned in issue #19 this should be the better default value for INLINE_HINTS. 
Although I don't know why they are named INLAY_HINT and not INLINE_HINT_DEFAULT. 
But when I imported the theme as icls file it looked good. 